### PR TITLE
Fix  participatory process filter routes

### DIFF
--- a/app/middleware/participatory_processes_scoper.rb
+++ b/app/middleware/participatory_processes_scoper.rb
@@ -51,7 +51,7 @@ class ParticipatoryProcessesScoper
   private
 
   def reset_participatory_process_model_default_scope
-    Decidim::ParticipatoryProcess.scope_from_slug_prefixes(nil, nil)
+    Decidim::ParticipatoryProcess.scope_from_slug_prefixes(nil, nil, nil)
   end
 
   def scoped_slug_prefixes
@@ -114,11 +114,11 @@ class ParticipatoryProcessesScoper
   end
 
   def exclude_alternative_participatory_processes_from_default_scope
-    Decidim::ParticipatoryProcess.scope_from_slug_prefixes(scoped_slug_prefixes.values.flatten, :exclude)
+    Decidim::ParticipatoryProcess.scope_from_slug_prefixes(scoped_slug_prefixes.values.flatten, :exclude, request_namespace)
   end
 
   def exclude_normal_participatory_processes_from_default_scope
-    Decidim::ParticipatoryProcess.scope_from_slug_prefixes(scoped_slug_prefixes[request_namespace], :include)
+    Decidim::ParticipatoryProcess.scope_from_slug_prefixes(scoped_slug_prefixes[request_namespace], :include, request_namespace)
   end
 
   def redirect(namespace)

--- a/config/initializers/participatory_processes_default_type_scopes.rb
+++ b/config/initializers/participatory_processes_default_type_scopes.rb
@@ -8,11 +8,12 @@ Rails.configuration.middleware.use ParticipatoryProcessesScoper
 Rails.application.config.to_prepare do
   Decidim::ParticipatoryProcess.class_eval do
     class << self
-      attr_accessor :scoped_slug_prefixes, :scoped_slug_prefixes_mode
+      attr_accessor :scoped_slug_prefixes, :scoped_slug_prefixes_mode, :scoped_slug_namespace
 
-      def scope_from_slug_prefixes(slugs, mode)
+      def scope_from_slug_prefixes(slugs, mode, namespace)
         self.scoped_slug_prefixes = slugs
         self.scoped_slug_prefixes_mode = mode
+        self.scoped_slug_namespace = namespace
       end
     end
 
@@ -27,6 +28,40 @@ Rails.application.config.to_prepare do
       when :include
         where("slug LIKE ANY (ARRAY[?])", slug_prefixes)
       end
+    end
+  end
+
+  Decidim::ParticipatoryProcesses::ProcessFiltersCell.class_eval do
+    def filter_link(filter)
+      current_participatory_processes_path(
+        filter: {
+          scope_id: get_filter(:scope_id),
+          area_id: get_filter(:area_id),
+          date: filter
+        }
+      )
+    end
+
+    private
+
+    # use the alternate url for generating filters if we are scoped
+    def current_participatory_processes_path(filter)
+      if Decidim::ParticipatoryProcess.scoped_slug_namespace != ParticipatoryProcessesScoper::DEFAULT_NAMESPACE
+        return alternative_filter_link(Decidim::ParticipatoryProcess.scoped_slug_namespace, filter)
+      end
+
+      normal_filter_link(filter)
+    end
+
+    def alternative_filter_link(key, filter)
+      Rails.application.routes.url_helpers.send("#{key}_path", filter)
+    end
+
+    def normal_filter_link(filter)
+      Decidim::ParticipatoryProcesses::Engine
+        .routes
+        .url_helpers
+        .participatory_processes_path(filter)
     end
   end
 end

--- a/spec/middleware/participatory_processes_scoper_spec.rb
+++ b/spec/middleware/participatory_processes_scoper_spec.rb
@@ -27,7 +27,7 @@ describe ParticipatoryProcessesScoper do
   end
 
   before do
-    Decidim::ParticipatoryProcess.scope_from_slug_prefixes(nil, nil)
+    Decidim::ParticipatoryProcess.scope_from_slug_prefixes(nil, nil, nil)
 
     allow(ParticipatoryProcessesScoper)
       .to receive(:scoped_participatory_process_slug_prefixes)
@@ -52,9 +52,10 @@ describe ParticipatoryProcessesScoper do
   shared_examples "untampered participatory_process model" do
     it "participatory_process model is not tampered" do
       # ensure model is always reset after calling the middleware
-      Decidim::ParticipatoryProcess.scope_from_slug_prefixes(["deu"], :include)
+      Decidim::ParticipatoryProcess.scope_from_slug_prefixes(["deu"], :include, "some_route")
       middleware.call(env)
 
+      expect(Decidim::ParticipatoryProcess.scoped_slug_namespace).not_to be_present
       expect(Decidim::ParticipatoryProcess.scoped_slug_prefixes).not_to be_present
       expect(Decidim::ParticipatoryProcess.scoped_slug_prefixes_mode).not_to be_present
     end
@@ -82,6 +83,7 @@ describe ParticipatoryProcessesScoper do
     it "participatory_process model is tampered with exclude slug_prefixes" do
       middleware.call(env)
 
+      expect(path).to match(/^#{Decidim::ParticipatoryProcess.scoped_slug_namespace}/)
       expect(Decidim::ParticipatoryProcess.scoped_slug_prefixes).to eq(slug_prefixes)
       expect(Decidim::ParticipatoryProcess.scoped_slug_prefixes_mode).to eq(:exclude)
     end
@@ -100,6 +102,7 @@ describe ParticipatoryProcessesScoper do
     it "participatory_process model is tampered with include slug_prefixes" do
       middleware.call(env)
 
+      expect(path).to match(/^#{Decidim::ParticipatoryProcess.scoped_slug_namespace}/)
       expect(Decidim::ParticipatoryProcess.scoped_slug_prefixes).to eq(slug_prefixes)
       expect(Decidim::ParticipatoryProcess.scoped_slug_prefixes_mode).to eq(:include)
     end

--- a/spec/models/participatory_process_spec.rb
+++ b/spec/models/participatory_process_spec.rb
@@ -6,16 +6,18 @@ module Decidim
   describe ParticipatoryProcess do
     let!(:organization) { create(:organization) }
     let(:scoped_slug_prefix) { "alternative" }
+    let(:namespace) { "alternative_processes" }
     let!(:alternative_process) { create(:participatory_process, slug: "#{scoped_slug_prefix}-slug", organization: organization) }
     let!(:normal_process) { create(:participatory_process, slug: "normal-slug", organization: organization) }
 
     context "when no scope types" do
       before do
-        ParticipatoryProcess.scope_from_slug_prefixes(nil, nil)
+        ParticipatoryProcess.scope_from_slug_prefixes(nil, nil, nil)
       end
 
       it "has no default scope" do
         expect(ParticipatoryProcess.default_scope).not_to be_present
+        expect(ParticipatoryProcess.scoped_slug_namespace).not_to be_present
         expect(ParticipatoryProcess.scoped_slug_prefixes).not_to be_present
         expect(ParticipatoryProcess.scoped_slug_prefixes_mode).not_to be_present
       end
@@ -29,11 +31,12 @@ module Decidim
 
     context "when scope types are in :include mode" do
       before do
-        ParticipatoryProcess.scope_from_slug_prefixes([scoped_slug_prefix], :include)
+        ParticipatoryProcess.scope_from_slug_prefixes([scoped_slug_prefix], :include, namespace)
       end
 
       it "has a default scope" do
         expect(ParticipatoryProcess.default_scope).to be_present
+        expect(ParticipatoryProcess.scoped_slug_namespace).to eq(namespace)
         expect(ParticipatoryProcess.scoped_slug_prefixes).to eq([scoped_slug_prefix])
         expect(ParticipatoryProcess.scoped_slug_prefixes_mode).to eq(:include)
       end
@@ -47,11 +50,12 @@ module Decidim
 
     context "when scope types are in :exclude mode" do
       before do
-        ParticipatoryProcess.scope_from_slug_prefixes([scoped_slug_prefix], :exclude)
+        ParticipatoryProcess.scope_from_slug_prefixes([scoped_slug_prefix], :exclude, namespace)
       end
 
       it "has a default scope" do
         expect(ParticipatoryProcess.default_scope).to be_present
+        expect(ParticipatoryProcess.scoped_slug_namespace).to eq(namespace)
         expect(ParticipatoryProcess.scoped_slug_prefixes).to eq([scoped_slug_prefix])
         expect(ParticipatoryProcess.scoped_slug_prefixes_mode).to eq(:exclude)
       end


### PR DESCRIPTION
related to #68

When filtering participatory processes, the filter route must be adapted to match the alternative definitions.