### PR TITLE
Fix resource_icon with component or manifest nil

### DIFF
--- a/app/helpers/decidim/icon_helper.rb
+++ b/app/helpers/decidim/icon_helper.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module Decidim
+  # Helpers related to icons
+  module IconHelper
+    include Decidim::LayoutHelper
+
+    # Public: Returns an icon given an instance of a Component. It defaults to
+    # a question mark when no icon is found.
+    #
+    # component - The component to generate the icon for.
+    # options - a Hash with options
+    #
+    # Returns an HTML tag with the icon.
+    def component_icon(component, options = {})
+      manifest_icon(component.manifest, options)
+    end
+
+    # Public: Returns an icon given an instance of a Manifest. It defaults to
+    # a question mark when no icon is found.
+    #
+    # manifest - The manifest to generate the icon for.
+    # options - a Hash with options
+    #
+    # Returns an HTML tag with the icon.
+    def manifest_icon(manifest, options = {})
+      if manifest.respond_to?(:icon) && manifest.icon.present?
+        external_icon manifest.icon, options
+      else
+        icon "question-mark", options
+      end
+    end
+
+    # Public: Finds the correct icon for the given resource. If the resource has a
+    # Component then it uses it to find the icon, otherwise checks for the resource
+    # manifest to find the icon.
+    #
+    # resource - The resource to generate the icon for.
+    # options - a Hash with options
+    #
+    # Returns an HTML tag with the icon.
+    def resource_icon(resource, options = {})
+      if resource.class.name == "Decidim::Comments::Comment"
+        icon "comment-square", options
+      elsif resource.respond_to?(:component) && resource.component.present?
+        component_icon(resource.component, options)
+      elsif resource.respond_to?(:manifest) && resource.manifest.present?
+        manifest_icon(resource.manifest, options)
+      elsif resource.is_a?(Decidim::User)
+        icon "person", options
+      else
+        icon "bell", options
+      end
+    end
+  end
+end

--- a/spec/lib/overrides_spec.rb
+++ b/spec/lib/overrides_spec.rb
@@ -10,6 +10,7 @@ checksums = [
     package: "decidim-core",
     files: {
       "/app/controllers/decidim/devise/invitations_controller.rb" => "faa5403c358f686a87eea2d9f4eaf1d4",
+      "/app/helpers/decidim/icon_helper.rb" => "952fac462893c32fbd367cea72be38cb",
       "/app/views/layouts/decidim/mailer.html.erb" => "5bbe335c1dfd02f8448af287328a49dc"
     }
   },


### PR DESCRIPTION
See https://github.com/decidim/decidim/pull/10134.

It will be included in v0.28 so at the moment this instance reaches this version it won't be necessary and could be safely deleted.