### PR TITLE
Remove babel from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,6 @@ COPY ./public/fonts /app/public/fonts
 COPY ./public/images /app/public/images
 COPY ./config.ru /app/config.ru
 COPY ./Rakefile /app/Rakefile
-COPY ./babel.config.json /app/babel.config.json
 COPY ./postcss.config.js /app/postcss.config.js
 
 # Compile assets with Webpacker or Sprockets


### PR DESCRIPTION
## Description

The babel file in the Dockerfile does not allow docker to build the image. We have to remove it since it's not part of decidim 0.29.